### PR TITLE
chore: update license year to 2026

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Flower-F <https://github.com/flower-f>
+Copyright (c) 2026 Flower-F <https://github.com/flower-f>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update LICENSE copyright year from 2024 to 2026.